### PR TITLE
fix: QuerySetメソッドのif/else条件反転バグを修正

### DIFF
--- a/videopost/models.py
+++ b/videopost/models.py
@@ -21,28 +21,24 @@ class TagQuerySet(models.QuerySet):
 
 class WhenClickQuerySet(models.QuerySet):
     def get_tag_click_value_per_day(self, tag_name=""):
-        query_set = self.get_queryset()
         now = timezone.now()
         one_day_ago = now - timezone.timedelta(days=1)
         if tag_name:
-            li = list(query_set.filter(date__gte=one_day_ago, date__lte=now).values(
-                "tagid").annotate(models.Count("tagid")))
-            di = {}
-            list(map(lambda x: di.update({x["tagid"]: x["tagid__count"]}), li))
-            return di
+            return self.filter(date__gte=one_day_ago, date__lte=now, tagid__exact=tag_name).count()
         else:
-            return query_set.filter(date__gte=one_day_ago, date__lte=now, tagid__exact=tag_name).count()
+            li = list(self.filter(date__gte=one_day_ago, date__lte=now).values(
+                "tagid").annotate(models.Count("tagid")))
+            return {x["tagid"]: x["tagid__count"] for x in li}
 
 
 class VideoClickQuerySet(models.QuerySet):
     def get_tag_upload_value(self, tag_name=""):
-        query_set = self.get_queryset()
         now = timezone.now()
         one_day_ago = now - timezone.timedelta(days=1)
         if tag_name:
-            return list(query_set.filter(uploaded__gte=one_day_ago, uploaded__lte=now))
+            return self.filter(uploaded__gte=one_day_ago, uploaded__lte=now, tags__name=tag_name).count()
         else:
-            return query_set.filter(tagid__exact=tag_name).count()
+            return list(self.filter(uploaded__gte=one_day_ago, uploaded__lte=now))
 
 
 class Account(models.Model):


### PR DESCRIPTION
## 概要

`videopost/models.py` の `WhenClickQuerySet` と `VideoClickQuerySet` に存在した重大な論理エラーを修正しました。

## 修正内容

### `WhenClickQuerySet.get_tag_click_value_per_day()`

- **条件反転バグ修正**: `tag_name` が指定された場合に全タグ集計を返し、未指定時に指定タグの件数を返すという逆の動作をしていた
- **不正メソッド呼び出し修正**: `self.get_queryset()`（QuerySet には存在しない Manager のメソッド）を `self` への直接参照に変更（AttributeError 防止）
- **dict生成の簡潔化**: `list(map(lambda ...))` の副作用依存 → dict 内包表記

### `VideoClickQuerySet.get_tag_upload_value()`

- **条件反転バグ修正**: 同様に `if tag_name:` / `else:` の処理が逆になっていた
- **フィールド名修正**: `tagid__exact`（Video モデルに存在しないフィールド）→ `tags__name`（ManyToMany の正しいルックアップ）
- **不正メソッド呼び出し修正**: 同上

## テスト計画

- [ ] `WhenClickQuerySet.get_tag_click_value_per_day(tag_name="some_tag")` が件数（int）を返すことを確認
- [ ] `WhenClickQuerySet.get_tag_click_value_per_day()` が `{tagid: count}` の dict を返すことを確認
- [ ] `VideoClickQuerySet.get_tag_upload_value(tag_name="some_tag")` が件数（int）を返すことを確認
- [ ] `VideoClickQuerySet.get_tag_upload_value()` が Video のリストを返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)