### PR TITLE
fix: セキュリティ脆弱性の修正（RSA秘密鍵・パストラバーサル・SSRF・設定）

### DIFF
--- a/env1/settings.py
+++ b/env1/settings.py
@@ -29,10 +29,9 @@ env.read_env(path.join(BASE_DIR, '.env'))
 SECRET_KEY = env('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env.bool('DEBUG', default=False)
 
-ALLOWED_HOSTS = ['192.168.10.106', '127.0.0.1',
-                 '10.228.179.236', '10.0.54.27', '192.168.2.208', "*"]
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['127.0.0.1', '192.168.10.106', '10.228.179.236', '10.0.54.27', '192.168.2.208'])
 
 
 # Application definition

--- a/videopost/views.py
+++ b/videopost/views.py
@@ -44,15 +44,16 @@ def assign_unique_id(request):
     if request.method == "GET":
         public_key, private_key = generate_key()
         public_key = public_key.decode()
-        with open("./videopost/temp/private.pem", "wb") as f:
-            f.write(private_key)
+        # ユーザーごとのセッションに保存（共有ファイルへの平文保存を廃止）
+        request.session["temp_private_key"] = base64.b64encode(private_key).decode()
         return JsonResponse({"public_key": public_key})
     elif request.method == "POST":
         user_id = request.POST.get("userId")
-        with open("./videopost/temp/private.pem", "rb") as f:
-            private_key = f.read()
-            Account.objects.create(
-                accountid=user_id, privatekey=private_key.decode())
+        private_key_b64 = request.session.pop("temp_private_key", None)
+        if not private_key_b64:
+            return JsonResponse({"error": "session expired"}, status=400)
+        private_key = base64.b64decode(private_key_b64)
+        Account.objects.create(accountid=user_id, privatekey=private_key.decode())
         return JsonResponse({"response": "success"})
 
 
@@ -169,9 +170,10 @@ def trim_video(request):
         video_path = request.POST.get("videoPath")
         start_time = request.POST.get("startTime")
         end_time = request.POST.get("endTime")
-        path = os.path.join(settings.STATIC_ROOT, video_path[8:].split("?")[0])
-        print(start_time)
-        print(end_time)
+        relative_path = video_path.lstrip("/").removeprefix("static/").split("?")[0]
+        path = os.path.abspath(os.path.join(settings.STATIC_ROOT, relative_path))
+        if not path.startswith(os.path.abspath(str(settings.STATIC_ROOT)) + os.sep):
+            return JsonResponse({"error": "invalid path"}, status=400)
         clip = moviepy.editor.VideoFileClip(path)
         trimed = clip.subclip(float(start_time), float(end_time))
         trimed_path = os.path.join(os.path.dirname(path), "trimed.mp4")
@@ -413,9 +415,8 @@ def test_ipfs(request):
 
 
 def test(request):
+    if not settings.DEBUG:
+        return JsonResponse({"error": "not found"}, status=404)
     url = request.GET.get("url")
-    print(request.GET)
-    print(url)
     r = requests.get(url)
-    print(str(r.content)[2:])
     return JsonResponse({"response": str(r.content)[2:]})


### PR DESCRIPTION
## 概要

`views.py` と `settings.py` に存在した4件のセキュリティ脆弱性を修正しました。

## 修正内容

### 🔴 RSA秘密鍵の平文ファイル保存 (`views.py` `assign_unique_id()`)

**問題**: GET で生成した RSA 秘密鍵を `./videopost/temp/private.pem` に書き込み、POST で読み込んでいた。
- 複数ユーザーが同じファイルを上書きし合う競合が発生
- ファイルがプロジェクト内に残存し Git 管理対象になるリスク

**修正**: 秘密鍵を base64 エンコードしてユーザーごとのセッションに保存。セッションに鍵がない場合は 400 を返す。

### 🔴 パストラバーサル (`views.py` `trim_video()`)

**問題**: ユーザー入力の `videoPath` を `video_path[8:]` で単純にスライスして `os.path.join()` に渡していた。`../` を含むパスで `STATIC_ROOT` の外のファイルにアクセス可能。

**修正**: `os.path.abspath()` で正規化後、`STATIC_ROOT` 配下であることを `startswith()` で検証。範囲外は 400 を返す。

### 🔴 SSRF (`views.py` `test()`)

**問題**: ユーザー指定の任意 URL にサーバーからリクエストを送信（内部サービスへのアクセスに悪用可能）。

**修正**: `DEBUG=False` 環境では 404 を返し、開発環境専用に制限。

### 🟠 `DEBUG=True` ハードコード・`ALLOWED_HOSTS` ワイルドカード (`settings.py`)

**問題**:
- `DEBUG = True` がハードコードされており、本番環境でも詳細なエラー情報が露出する
- `ALLOWED_HOSTS` に `"*"` があり Host Header Injection に脆弱

**修正**:
- `DEBUG = env.bool('DEBUG', default=False)` で環境変数から読み込み（デフォルト無効）
- `ALLOWED_HOSTS` の `"*"` を除去し `env.list()` から読み込むよう変更

## 開発環境での対応が必要な設定

`.env` ファイルに以下を追加してください：

```
DEBUG=True
ALLOWED_HOSTS=127.0.0.1,192.168.10.106
```

## テスト計画

- [ ] `assign_unique_id` GET → POST の通常フロー（秘密鍵が正常に Account に保存される）
- [ ] `assign_unique_id` POST を GET なしで呼んだ場合に 400 が返ること
- [ ] `trim_video` に `../` を含むパスを送信して 400 が返ること
- [ ] `test()` エンドポイントが `DEBUG=False` 時に 404 を返すこと
- [ ] `DEBUG=True` を `.env` に設定して開発サーバーが正常起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)