### PR TITLE
feat(ui-renewal): Step 3 — デスクトップレスポンシブ対応

### DIFF
--- a/videopost/static/js/scroll.js
+++ b/videopost/static/js/scroll.js
@@ -83,7 +83,7 @@ const infiniteScroll = createApp({
           }
         })
         setTimeout(() => {
-          const videoElementList = Array.from(document.querySelectorAll(".infinite-item > video"))
+          const videoElementList = Array.from(document.querySelectorAll(".infinite-item video"))
           videoElementList.forEach(ele => {
             if (!(videoElementVisibilities.map(ele => { return ele.element }).includes(ele))) {
               ele.load()
@@ -120,7 +120,7 @@ const infiniteScroll = createApp({
       await addVideos()
       await nextTick()  // v-for による <video> 要素の DOM 反映を待つ
       fadeUp()
-      currentVideoElement.value = document.querySelector(".infinite-item > video")
+      currentVideoElement.value = document.querySelector(".infinite-item video")
       console.log(currentVideoElement.value)
       console.log(videoElementVisibilities)
       console.log(dataList.value)

--- a/videopost/templates/index.html
+++ b/videopost/templates/index.html
@@ -240,28 +240,28 @@
                   <!-- モバイル: 右アクションバー（動画に重なるオーバーレイ） -->
                   <div class="absolute right-3 bottom-28 z-10 flex flex-col items-center gap-5 md:hidden">
                     <div class="flex flex-col items-center gap-1">
-                      <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
-                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
+                      <button aria-label="いいね" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
                       </button>
-                      <span class="text-text-1 text-label text-center w-16">12.4k</span>
+                      <span class="text-text-1 text-label text-center w-16" aria-hidden="true">12.4k</span>
                     </div>
                     <div class="flex flex-col items-center gap-1">
-                      <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
-                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
+                      <button aria-label="コメント" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
                       </button>
-                      <span class="text-text-1 text-label text-center w-16">318</span>
+                      <span class="text-text-1 text-label text-center w-16" aria-hidden="true">318</span>
                     </div>
                     <div class="flex flex-col items-center gap-1">
-                      <button @click.stop="shareLink" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
-                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
+                      <button aria-label="共有" @click.stop="shareLink" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
                       </button>
-                      <span class="text-text-1 text-label text-center w-16">共有</span>
+                      <span class="text-text-1 text-label text-center w-16" aria-hidden="true">共有</span>
                     </div>
                     <div class="flex flex-col items-center gap-1">
-                      <button class="w-12 h-12 rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
-                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
+                      <button aria-label="所有" class="w-12 h-12 rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
+                        <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
                       </button>
-                      <span class="text-accent text-label text-center w-16">所有</span>
+                      <span class="text-accent text-label text-center w-16" aria-hidden="true">所有</span>
                     </div>
                   </div>
 
@@ -307,28 +307,28 @@
                 <!-- デスクトップ: 右アクションバー（カード外、フロー内） -->
                 <div class="hidden md:flex flex-col items-center gap-5">
                   <div class="flex flex-col items-center gap-1">
-                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
+                    <button aria-label="いいね" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
                     </button>
-                    <span class="text-text-2 text-caption text-center w-20">12.4k</span>
+                    <span class="text-text-2 text-caption text-center w-20" aria-hidden="true">12.4k</span>
                   </div>
                   <div class="flex flex-col items-center gap-1">
-                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
+                    <button aria-label="コメント" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
                     </button>
-                    <span class="text-text-2 text-caption text-center w-20">318</span>
+                    <span class="text-text-2 text-caption text-center w-20" aria-hidden="true">318</span>
                   </div>
                   <div class="flex flex-col items-center gap-1">
-                    <button @click.stop="shareLink" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
+                    <button aria-label="共有" @click.stop="shareLink" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
                     </button>
-                    <span class="text-text-2 text-caption text-center w-20">共有</span>
+                    <span class="text-text-2 text-caption text-center w-20" aria-hidden="true">共有</span>
                   </div>
                   <div class="flex flex-col items-center gap-1">
-                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
+                    <button aria-label="所有" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
+                      <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
                     </button>
-                    <span class="text-accent text-caption text-center w-20">所有</span>
+                    <span class="text-accent text-caption text-center w-20" aria-hidden="true">所有</span>
                   </div>
                 </div><!-- /デスクトップ右アクション -->
 

--- a/videopost/templates/index.html
+++ b/videopost/templates/index.html
@@ -197,7 +197,7 @@
                 <!-- ── 動画ラッパー ──
                      mobile : w-full h-full（フルスクリーン）
                      desktop: 398×708 rounded card（Figma準拠） -->
-                <div class="relative w-full h-full
+                <div class="relative w-full h-full flex items-center justify-center
                             md:w-[398px] md:h-[708px] md:flex-shrink-0
                             md:rounded-24 md:overflow-hidden md:bg-surface-2">
 

--- a/videopost/templates/index.html
+++ b/videopost/templates/index.html
@@ -240,13 +240,13 @@
                   <!-- モバイル: 右アクションバー（動画に重なるオーバーレイ） -->
                   <div class="absolute right-3 bottom-28 z-10 flex flex-col items-center gap-5 md:hidden">
                     <div class="flex flex-col items-center gap-1">
-                      <button aria-label="いいね" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                      <button aria-label="いいね 12.4k" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
                         <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
                       </button>
                       <span class="text-text-1 text-label text-center w-16" aria-hidden="true">12.4k</span>
                     </div>
                     <div class="flex flex-col items-center gap-1">
-                      <button aria-label="コメント" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                      <button aria-label="コメント 318件" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
                         <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
                       </button>
                       <span class="text-text-1 text-label text-center w-16" aria-hidden="true">318</span>
@@ -307,13 +307,13 @@
                 <!-- デスクトップ: 右アクションバー（カード外、フロー内） -->
                 <div class="hidden md:flex flex-col items-center gap-5">
                   <div class="flex flex-col items-center gap-1">
-                    <button aria-label="いいね" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                    <button aria-label="いいね 12.4k" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
                       <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
                     </button>
                     <span class="text-text-2 text-caption text-center w-20" aria-hidden="true">12.4k</span>
                   </div>
                   <div class="flex flex-col items-center gap-1">
-                    <button aria-label="コメント" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                    <button aria-label="コメント 318件" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
                       <svg aria-hidden="true" class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
                     </button>
                     <span class="text-text-2 text-caption text-center w-20" aria-hidden="true">318</span>

--- a/videopost/templates/index.html
+++ b/videopost/templates/index.html
@@ -189,100 +189,148 @@
               </div>
             </div>
 
-            <!-- 動画無限スクロール（JSの .infinite-item > video セレクタを維持） -->
+            <!-- 動画無限スクロール（JSの .infinite-item video セレクタを維持） -->
             <div class="infinite-container" id="container" ref="container">
-              <div v-for="(item, index) in dataList" class="infinite-item">
-                <video playsinline :src="blobVideos[index]" height="100%" autoplay loop
-                       @click.prevent="togglePlayAndGood"></video>
+              <div v-for="(item, index) in dataList"
+                   class="infinite-item md:items-center md:gap-9">
 
-                <!-- 右アクションバー -->
-                <div class="absolute right-3 bottom-28 z-10 flex flex-col items-center gap-5">
-                  <!-- いいね -->
-                  <div class="flex flex-col items-center gap-1">
-                    <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline
-                                   flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/>
-                      </svg>
-                    </button>
-                    <span class="text-text-1 text-label text-center w-16">12.4k</span>
-                  </div>
-                  <!-- コメント -->
-                  <div class="flex flex-col items-center gap-1">
-                    <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline
-                                   flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/>
-                      </svg>
-                    </button>
-                    <span class="text-text-1 text-label text-center w-16">318</span>
-                  </div>
-                  <!-- 共有 -->
-                  <div class="flex flex-col items-center gap-1">
-                    <button @click.stop="shareLink"
-                            class="w-12 h-12 rounded-full bg-black/40 border border-hairline
-                                   flex items-center justify-center text-text-1">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/>
-                      </svg>
-                    </button>
-                    <span class="text-text-1 text-label text-center w-16">共有</span>
-                  </div>
-                  <!-- 所有 -->
-                  <div class="flex flex-col items-center gap-1">
-                    <button class="w-12 h-12 rounded-full bg-surface-2/80
-                                   flex items-center justify-center text-accent">
-                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/>
-                      </svg>
-                    </button>
-                    <span class="text-accent text-label text-center w-16">所有</span>
-                  </div>
-                </div>
+                <!-- ── 動画ラッパー ──
+                     mobile : w-full h-full（フルスクリーン）
+                     desktop: 398×708 rounded card（Figma準拠） -->
+                <div class="relative w-full h-full
+                            md:w-[398px] md:h-[708px] md:flex-shrink-0
+                            md:rounded-24 md:overflow-hidden md:bg-surface-2">
 
-                <!-- 下部情報オーバーレイ（モバイル） -->
-                <div class="absolute bottom-0 left-0 right-0 z-10 md:hidden">
-                  <div class="px-5 pt-20 pb-4
-                              bg-gradient-to-t from-black/70 via-black/30 to-transparent">
-                    <!-- 24時間バッジ -->
-                    <div class="inline-flex items-center gap-1.5 h-7 px-3 mb-3
-                                bg-black/45 border border-hairline rounded-pill">
-                      <svg class="w-3.5 h-3.5 text-text-1 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-                      </svg>
-                      <span class="text-text-1 text-caption">24時間で消去</span>
+                  <video playsinline :src="blobVideos[index]" height="100%" autoplay loop
+                         @click.prevent="togglePlayAndGood"></video>
+
+                  <!-- デスクトップ: 24時間バッジ（カード左上） -->
+                  <div class="hidden md:inline-flex absolute top-4 left-4 z-10
+                              items-center gap-1.5 h-7 px-3
+                              bg-black/45 border border-hairline rounded-pill">
+                    <svg class="w-3.5 h-3.5 text-text-1 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+                    </svg>
+                    <span class="text-text-1 text-caption">24時間で消去</span>
+                  </div>
+
+                  <!-- デスクトップ: カード下部オーバーレイ（ユーザー・タイトル） -->
+                  <div class="hidden md:block absolute bottom-0 left-0 right-0 z-10
+                              bg-gradient-to-t from-black/60 via-black/30 to-transparent">
+                    <div class="px-4 pt-16 pb-3">
+                      <div class="flex items-center gap-2 mb-1.5">
+                        <svg class="w-4 h-4 text-text-2 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                        </svg>
+                        <span class="text-text-1 text-meta font-semibold">@anon</span>
+                        <span class="text-text-2 text-meta">· 匿名投稿</span>
+                      </div>
+                      <p class="text-text-1 text-[16px] font-semibold truncate"
+                         v-if="item.title">[[ item.title ]]</p>
                     </div>
-                    <!-- ユーザー情報 -->
-                    <div class="flex items-center gap-2 mb-1.5">
-                      <svg class="w-4 h-4 text-text-2 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
-                      </svg>
-                      <span class="text-text-1 text-meta font-semibold">@anon</span>
-                      <span class="text-text-2 text-meta">· 匿名投稿</span>
-                    </div>
-                    <!-- タイトル -->
-                    <p class="text-text-1 text-title mb-1.5" v-if="item.title">[[ item.title ]]</p>
-                    <!-- 説明文 -->
-                    <p class="text-text-2 text-body mb-3 line-clamp-2" v-if="item.description">[[ item.description ]]</p>
-                    <!-- タグ -->
-                    <div class="flex flex-wrap gap-2" v-if="item.tags && item.tags.length">
-                      <span v-for="tag in item.tags"
-                            class="inline-flex items-center h-[30px] px-3
-                                   bg-surface-2/85 text-text-1 text-meta rounded-pill">
-                        #[[ tag ]]
-                      </span>
+                    <!-- プログレスバー（デスクトップ） -->
+                    <div class="relative h-1 bg-white/15">
+                      <div class="absolute left-0 top-0 h-1 bg-accent" style="width:38%">
+                        <span class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2
+                                     w-[9px] h-[9px] rounded-full bg-accent block"></span>
+                      </div>
                     </div>
                   </div>
-                  <!-- プログレスバー -->
-                  <div class="relative h-[3px] bg-white/15">
-                    <div class="absolute left-0 top-0 h-[3px] bg-accent" style="width:38%">
-                      <span class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2
-                                   w-2.5 h-2.5 rounded-full bg-accent block"></span>
+
+                  <!-- モバイル: 右アクションバー（動画に重なるオーバーレイ） -->
+                  <div class="absolute right-3 bottom-28 z-10 flex flex-col items-center gap-5 md:hidden">
+                    <div class="flex flex-col items-center gap-1">
+                      <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
+                      </button>
+                      <span class="text-text-1 text-label text-center w-16">12.4k</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                      <button class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
+                      </button>
+                      <span class="text-text-1 text-label text-center w-16">318</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                      <button @click.stop="shareLink" class="w-12 h-12 rounded-full bg-black/40 border border-hairline flex items-center justify-center text-text-1">
+                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
+                      </button>
+                      <span class="text-text-1 text-label text-center w-16">共有</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                      <button class="w-12 h-12 rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
+                        <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
+                      </button>
+                      <span class="text-accent text-label text-center w-16">所有</span>
                     </div>
                   </div>
-                  <!-- ボトムナビバー分のスペーサー -->
-                  <div class="h-20"></div>
-                </div>
+
+                  <!-- モバイル: 下部情報オーバーレイ -->
+                  <div class="absolute bottom-0 left-0 right-0 z-10 md:hidden">
+                    <div class="px-5 pt-20 pb-4
+                                bg-gradient-to-t from-black/70 via-black/30 to-transparent">
+                      <div class="inline-flex items-center gap-1.5 h-7 px-3 mb-3
+                                  bg-black/45 border border-hairline rounded-pill">
+                        <svg class="w-3.5 h-3.5 text-text-1 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+                        </svg>
+                        <span class="text-text-1 text-caption">24時間で消去</span>
+                      </div>
+                      <div class="flex items-center gap-2 mb-1.5">
+                        <svg class="w-4 h-4 text-text-2 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/>
+                        </svg>
+                        <span class="text-text-1 text-meta font-semibold">@anon</span>
+                        <span class="text-text-2 text-meta">· 匿名投稿</span>
+                      </div>
+                      <p class="text-text-1 text-title mb-1.5" v-if="item.title">[[ item.title ]]</p>
+                      <p class="text-text-2 text-body mb-3 line-clamp-2" v-if="item.description">[[ item.description ]]</p>
+                      <div class="flex flex-wrap gap-2" v-if="item.tags && item.tags.length">
+                        <span v-for="tag in item.tags"
+                              class="inline-flex items-center h-[30px] px-3
+                                     bg-surface-2/85 text-text-1 text-meta rounded-pill">
+                          #[[ tag ]]
+                        </span>
+                      </div>
+                    </div>
+                    <div class="relative h-[3px] bg-white/15">
+                      <div class="absolute left-0 top-0 h-[3px] bg-accent" style="width:38%">
+                        <span class="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2
+                                     w-2.5 h-2.5 rounded-full bg-accent block"></span>
+                      </div>
+                    </div>
+                    <div class="h-20"></div>
+                  </div>
+
+                </div><!-- /動画ラッパー -->
+
+                <!-- デスクトップ: 右アクションバー（カード外、フロー内） -->
+                <div class="hidden md:flex flex-col items-center gap-5">
+                  <div class="flex flex-col items-center gap-1">
+                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"/></svg>
+                    </button>
+                    <span class="text-text-2 text-caption text-center w-20">12.4k</span>
+                  </div>
+                  <div class="flex flex-col items-center gap-1">
+                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
+                    </button>
+                    <span class="text-text-2 text-caption text-center w-20">318</span>
+                  </div>
+                  <div class="flex flex-col items-center gap-1">
+                    <button @click.stop="shareLink" class="w-[52px] h-[52px] rounded-full bg-surface-2/80 border border-hairline flex items-center justify-center text-text-1">
+                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"/></svg>
+                    </button>
+                    <span class="text-text-2 text-caption text-center w-20">共有</span>
+                  </div>
+                  <div class="flex flex-col items-center gap-1">
+                    <button class="w-[52px] h-[52px] rounded-full bg-surface-2/80 flex items-center justify-center text-accent">
+                      <svg class="w-[26px] h-[26px]" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>
+                    </button>
+                    <span class="text-accent text-caption text-center w-20">所有</span>
+                  </div>
+                </div><!-- /デスクトップ右アクション -->
 
               </div><!-- /infinite-item -->
             </div><!-- /infinite-container -->


### PR DESCRIPTION
## 概要

Figma「01 · Main Feed — Desktop」に基づきデスクトップレイアウトを完成させます。  
**モバイルの挙動・JS ロジックは変更なし。**

---

## 変更内容

### 動画表示（`infinite-item` 内に動画ラッパー追加）

| | mobile (base) | desktop (`md:`) |
|---|---|---|
| 動画サイズ | full-screen | 398×708px（Figma準拠） |
| 角丸 | なし | `rounded-24` |
| 背景色 | なし | `surface-2` (#1C1C1F) |
| overflow | コンテナで制御 | `overflow-hidden`（角丸クリップ） |

### デスクトップ専用オーバーレイ（カード内）

- **24時間バッジ** — カード左上に `absolute` 配置
- **下部オーバーレイ** — ユーザー情報・タイトル・プログレスバー（グラデーション背景付き）

### アクションバー（いいね／コメント／共有／所有）の分離

```
mobile  : 動画に重なるオーバーレイ absolute（md:hidden） ← 既存のまま
desktop : カードの右横にフロー配置（hidden md:flex）
```

`infinite-item` に `md:items-center md:gap-9` を追加し、  
動画カード（398px） ＋ gap（36px） ＋ アクションバー（52px） がフレックスで横並び。

### `scroll.js` セレクタ修正

```diff
- document.querySelectorAll(".infinite-item > video")  // 直接子
+ document.querySelectorAll(".infinite-item video")    // 子孫
```

動画ラッパー div を挟んだため、直接子セレクタが機能しなくなるのを修正（2箇所）。

---

## レイアウト幅の計算（1440px 画面の場合）

```
サイドバー 240px │ 中央カラム（flex-1） │ 右パネル 408px + margin 24px
              ↕
         中央カラム ≈ 768px
         動画カード 398px + gap 36px + アクションバー ~52px = 486px
         → 中央寄せで各側 141px の余白
```

---

## ロードマップ

```
Step 1: Tailwind CDN + デザイントークン ✅
Step 2: index.html HTMLリライト ✅
Step 3: デスクトップレスポンシブ ← このPR
Step 4: アイコン整備・旧CSS削除・preflight 有効化
```

## テスト方法

1. **モバイル（〜767px）** — 既存と同じフルスクリーン動画・ボトムナビが表示されること
2. **デスクトップ（768px〜）**
   - 動画が 398×708 の rounded-24 カードで中央表示されること
   - アクションバーがカード右横（重なりなし）に表示されること
   - カード上部に「24時間で消去」バッジが表示されること
   - カード下部にユーザー情報・タイトル・プログレスバーが表示されること
3. スクロールスナップが引き続き動作すること